### PR TITLE
Api v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,17 +53,23 @@ This call will return the product's data as a `dict`:
             'https://outpan-images.s3.amazonaws.com/pjkhqlbgwl-0078915030900.mp4']}
 ```
 
-The `v1` API allows you to retrieve specific attributes of a product using the
-following methods:
+Accessing `v1` API
+------------------
+
+Available until Jan. 1st 2016, the `v1` API allows you to retrieve specific
+attributes of a product using the methods list below:
 
 ```python
+from outpan import OutpanApiV1  # Note that we are importing a different class
+
+api = OutpanApiV1(my_api_key)
 api.name("078915030900")
 api.attributes("078915030900")
 api.images("078915030900")
 api.videos("078915030900")
 ```
 
-The output of these calls is the `JSON` as returned by the API.
+The output of these calls is the `dict` as returned by the API.
 
 From the command line
 ---------------------
@@ -79,7 +85,7 @@ will give you the help message to know how to use it.
 A quick overview of the previous methods we've already talked about:
 
 ```bash
-python outpan.py 123456789 get-product 0796435419035
+python outpan.py 123456789 get-product 0796435419035  # Available for v2
 python outpan.py 123456789 name 0796435419035
 python outpan.py 123456789 attributes 0796435419035
 python outpan.py 123456789 images 0796435419035
@@ -87,7 +93,7 @@ python outpan.py 123456789 videos 0796435419035
 ```
 
 These command lines use the (fake) API key 123456789 to
-  1. Retrieve the full info of product 0796435419035
+  1. Retrieve the full info of product 0796435419035 - only command available for v2
   2. Retrieve the name of product 0796435419035
   3. Retrieve the attributes of product 0796435419035
   4. Retrieve the image links of product 0796435419035

--- a/README.rst
+++ b/README.rst
@@ -58,17 +58,23 @@ This call will return the product's data as a ``dict``:
                 'https://outpan-images.s3.amazonaws.com/nkvaonl839-0078915030900.mp4',
                 'https://outpan-images.s3.amazonaws.com/pjkhqlbgwl-0078915030900.mp4']}
 
-The ``v1`` API allows you to retrieve specific attributes of a product
-using the following methods:
+Accessing ``v1`` API
+--------------------
+
+Available until Jan. 1st 2016, the ``v1`` API allows you to retrieve
+specific attributes of a product using the methods list below:
 
 .. code:: python
 
+    from outpan import OutpanApiV1  # Note that we are importing a different class
+
+    api = OutpanApiV1(my_api_key)
     api.name("078915030900")
     api.attributes("078915030900")
     api.images("078915030900")
     api.videos("078915030900")
 
-The output of these calls is the ``JSON`` as returned by the API.
+The output of these calls is the ``dict`` as returned by the API.
 
 From the command line
 ---------------------
@@ -87,17 +93,17 @@ A quick overview of the previous methods we've already talked about:
 
 .. code:: bash
 
-    python outpan.py 123456789 get-product 0796435419035
+    python outpan.py 123456789 get-product 0796435419035  # Available for v2
     python outpan.py 123456789 name 0796435419035
     python outpan.py 123456789 attributes 0796435419035
     python outpan.py 123456789 images 0796435419035
     python outpan.py 123456789 videos 0796435419035
 
 These command lines use the (fake) API key 123456789 to 1. Retrieve the
-full info of product 0796435419035 2. Retrieve the name of product
-0796435419035 3. Retrieve the attributes of product 0796435419035 4.
-Retrieve the image links of product 0796435419035 5. Retrieve the video
-links of product 0796435419035
+full info of product 0796435419035 - only command available for v2 2.
+Retrieve the name of product 0796435419035 3. Retrieve the attributes of
+product 0796435419035 4. Retrieve the image links of product
+0796435419035 5. Retrieve the video links of product 0796435419035
 
 Creating or editing a product's name
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/outpan.py
+++ b/outpan.py
@@ -34,7 +34,7 @@ def _check_request_status(response):
 
 
 @parse_class(description="Simply access the outpan.com API with your api key.")
-class OutpanApi(object):
+class OutpanApiV1(object):
     """Access outpan.com v1 API with your api key."""
 
     _API_URL = "https://api.outpan.com/v1/products/"
@@ -108,10 +108,10 @@ class OutpanApi(object):
 
 
 def run_cli():
-    result = OutpanApi.parser.call()
+    result = OutpanApiV1.parser.call()
     pprint(result if result else "SUCCESS")
 
 
 if __name__ == "__main__":
-    RESULT = OutpanApi.parser.call()
+    RESULT = OutpanApiV1.parser.call()
     pprint(RESULT if RESULT else "SUCCESS")

--- a/outpan.py
+++ b/outpan.py
@@ -132,10 +132,10 @@ class OutpanApiV1(object):
 
 
 def run_cli():
-    result = OutpanApiV1.parser.call()
+    result = OutpanApi.parser.call()
     pprint(result if result else "SUCCESS")
 
 
 if __name__ == "__main__":
-    RESULT = OutpanApiV1.parser.call()
+    RESULT = OutpanApi.parser.call()
     pprint(RESULT if RESULT else "SUCCESS")

--- a/outpan.py
+++ b/outpan.py
@@ -33,9 +33,11 @@ def _check_request_status(response):
         return data
 
 
+@parse_class(description="Simply access the outpan.com API with you api key.")
 class OutpanApi(object):
     """Access outpan.com v2 API with your api key."""
 
+    @create_parser(Self, str, delimiter_chars="--")
     def __init__(self, api_key):
         """
         Args:
@@ -43,6 +45,7 @@ class OutpanApi(object):
         """
         self._api_key = api_key
 
+    @create_parser(Self, str, delimiter_chars="--")
     def get_product(self, barcode):
         """Return all the info about the given barcode.
 

--- a/outpan.py
+++ b/outpan.py
@@ -33,6 +33,27 @@ def _check_request_status(response):
         return data
 
 
+class OutpanApi(object):
+    """Access outpan.com v2 API with your api key."""
+
+    def __init__(self, api_key):
+        """
+        Args:
+            api_key -- the api key provided by outpan when you register
+        """
+        self._api_key = api_key
+
+    def get_product(self, barcode):
+        """Return all the info about the given barcode.
+
+        Args:
+            barcode -- the barcode/GTIN of the product
+        """
+        response = requests.get("https://api.outpan.com/v2/products/%s?apikey=%s"
+                               % (barcode, self._api_key))
+        return _check_request_status(response)
+
+
 @parse_class(description="Simply access the outpan.com API with your api key.")
 class OutpanApiV1(object):
     """Access outpan.com v1 API with your api key."""

--- a/outpan.py
+++ b/outpan.py
@@ -131,6 +131,11 @@ class OutpanApiV1(object):
         return self._get_resource("%s/videos" % barcode)
 
 
+def run_cli_v1():
+    result = OutpanApiV1.parser.call()
+    pprint(result if result else "SUCCESS")
+
+
 def run_cli():
     result = OutpanApi.parser.call()
     pprint(result if result else "SUCCESS")

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     entry_points={
         "console_scripts": [
             "outpan = outpan:run_cli",
+            "outpan-v1 = outpan:run_cli_v1",
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(README_PATH, "r") as readme_file:
 
 setup(
     name="outpan",
-    version="1.2.0",
+    version="2.0",
     description="Easily use Outpan API to get product info from its barcode",
     long_description=README,
     py_modules=["outpan"],


### PR DESCRIPTION
Introduce v2 API.
As it only allows to retrieve product's info we keep v1 API at least until it is removed from outpan servers.
